### PR TITLE
Add doc-comments to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ app.use(session({
 - **options.autoRemove** - Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`, will autodelete expired sessions on a set interval. Default: `never`
 - **options.autoRemoveInterval** - Sets the timer interval for each call to `destroyExpired()`. Default: `1000 * 60 * 10` (10 min)
 - **options.autoRemoveCallback** - (NOT CURRENTLY TESTED) Is the callback function for `destroyExpired()`. Default: `undefined`
+- **options.useUTC** - Determines if we are to use the `GETUTCDATE` instead of `GETDATE` Default: `true`
 
 ### Advanced usage
 NOT SETUP

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ app.use(session({
 
 - **options.table** - Table to use as session store. Default: `[sessions]`
 - **options.ttl** - (Time To Live) Determines the expiration date. Default: `1000 * 60 * 60 * 24` (24 hours)
-- **options.autoRemove** - Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`, will autodelete expired sessions on a set interval. Default: `never`
+- **options.autoRemove** - Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`, will autodelete expired sessions on a set interval. Default: `false`
 - **options.autoRemoveInterval** - Sets the timer interval for each call to `destroyExpired()`. Default: `1000 * 60 * 10` (10 min)
 - **options.autoRemoveCallback** - (NOT CURRENTLY TESTED) Is the callback function for `destroyExpired()`. Default: `undefined`
 - **options.useUTC** - Determines if we are to use the `GETUTCDATE` instead of `GETDATE` Default: `true`

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,7 +18,7 @@ interface StoreOptions {
   ttl?: number;
   /**
    * Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`,
-   * will autodelete expired sessions on a set interval. Default: `never`
+   * will autodelete expired sessions on a set interval. Default: `false`
    */
   autoRemove?: boolean;
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,11 +8,30 @@ import sql, {
 } from 'mssql';
 
 interface StoreOptions {
+  /**
+   * Table to use as session store. Default: `[sessions]`
+   */
   table?: string;
+  /**
+   * (Time To Live) Determines the expiration date. Default: `1000 * 60 * 60 * 24` (24 hours)
+   */
   ttl?: number;
+  /**
+   * Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`,
+   * will autodelete expired sessions on a set interval. Default: `never`
+   */
   autoRemove?: boolean;
+  /**
+   * Sets the timer interval for each call to `destroyExpired()`. Default: `1000 * 60 * 10` (10 min)
+   */
   autoRemoveInterval?: number;
+  /**
+   * (NOT CURRENTLY TESTED) Is the callback function for `destroyExpired()`. Default: `undefined`
+   */
   autoRemoveCallback?: (props: any) => any;
+  /**
+   * Determines if we are to use the `GETUTCDATE` instead of `GETDATE` Default: `true`
+   */
   useUTC?: boolean;
 }
 type Errors = ConnectionError | null;

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,7 +17,7 @@ interface StoreOptions {
    */
   ttl?: number;
   /**
-   * Determines if expired sessions should be autoremoved or not. If value is `interval` then a new function, `destroyExpired()`,
+   * Determines if expired sessions should be autoremoved or not. If value is `true` then a new function, `destroyExpired()`,
    * will autodelete expired sessions on a set interval. Default: `false`
    */
   autoRemove?: boolean;


### PR DESCRIPTION
- Add `useUTC` documentation, as it was missing.

Fix #4