### PR TITLE
Fix #11 - UnhandledPromiseRejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 All project updates will be documented in this file
 
 ## [Unreleased]
-
+[-sessionError event handler
+    -Seperate errorHandler method
+    ]
 ## [v1.1.0] - 2019-11-22
 - Typings updated [bf08351]
     - data property changed to session, use Express.SessionData type

--- a/README.md
+++ b/README.md
@@ -57,14 +57,18 @@ app.use(
 ```javascript
 const store = new MSSQLStore(config, options);
 
-store.on('connect', function() {
+store.on('connect', () => {
 	// ... connection established
 });
 
-store.on('error', function() {
+store.on('error', (error) => {
 	// ... connection error
 });
 
+store.on('sessionError', (error, classMethod) => {
+  // ... any error that occurs within a store method
+  // classMethod will return the method name (get, set, length, etc)
+})
 app.use(session({
     store: store
     secret: 'supersecret'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mssql-v2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -159,8 +159,8 @@ const Store = (
       this.databaseConnection.on('sessionError', (error, method) =>
         this.emit('sessionError', error, method)
       );
-
       this.databaseConnection.emit('sessionError', error, method);
+
       if (callback) {
         return callback(error);
       }
@@ -186,7 +186,7 @@ const Store = (
           if (result.recordset.length) {
             return callback(null, JSON.parse(result.recordset[0].session));
           }
-
+          
           return callback(null, null);
         } catch (error) {
           this.errorHandler('get', error, callback);

--- a/src/store.ts
+++ b/src/store.ts
@@ -146,6 +146,17 @@ const Store = (
         }
       }
     }
+
+    errorHandler(
+      method: string,
+      error: Errors,
+      callback?: CommonCallback | GetCallback | LengthCallback | ReadyCallback
+    ) {
+      this.databaseConnection.emit('sessionError', error, method);
+      if (callback) {
+        return callback(error);
+      }
+    }
     //////////////////////////////////////////////////////////////////
     // Attempt to fetch session the given sid
     /**
@@ -170,10 +181,7 @@ const Store = (
 
           return callback(null, null);
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'get');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('get', error, callback);
         }
       });
     }
@@ -220,10 +228,7 @@ const Store = (
 
           return callback();
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'set');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('set', error, callback);
         }
       });
     }
@@ -263,10 +268,7 @@ const Store = (
 
           return callback();
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'touch');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('touch', error, callback);
         }
       });
     }
@@ -292,10 +294,7 @@ const Store = (
 
           return callback();
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'destroy');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('destroy', error, callback);
         }
       });
     }
@@ -322,10 +321,7 @@ const Store = (
           if (this.autoRemoveCallback) {
             this.autoRemoveCallback(error);
           }
-          this.databaseConnection.emit('sessionError', error, 'destroyExpired');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('destroyExpired', error, callback);
         }
       });
     }
@@ -349,10 +345,7 @@ const Store = (
 
           return callback(null, result.recordset[0].length);
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'length');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('length', error, callback);
         }
       });
     }
@@ -375,10 +368,7 @@ const Store = (
 
           return callback();
         } catch (error) {
-          this.databaseConnection.emit('sessionError', error, 'clear');
-          if (callback) {
-            return callback(error);
-          }
+          this.errorHandler('clear', error, callback);
         }
       });
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -106,8 +106,11 @@ const Store = (
 
     private async initializeDatabase() {
       try {
+        // Emits on successful connection
         this.databaseConnection.on('connect', () => this.emit('connect', this));
+        // Emits on failed connection
         this.databaseConnection.on('error', error => this.emit('error', error));
+        // Emits on error of any store error and includes method where error occured
         this.databaseConnection.on('sessionError', (error, method) =>
           this.emit('sessionError', error, method)
         );
@@ -168,8 +171,8 @@ const Store = (
           return callback(null, null);
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'get');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -218,8 +221,8 @@ const Store = (
           return callback();
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'set');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -261,8 +264,8 @@ const Store = (
           return callback();
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'touch');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -290,8 +293,8 @@ const Store = (
           return callback();
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'destroy');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -320,8 +323,8 @@ const Store = (
             this.autoRemoveCallback(error);
           }
           this.databaseConnection.emit('sessionError', error, 'destroyExpired');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -347,8 +350,8 @@ const Store = (
           return callback(null, result.recordset[0].length);
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'length');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });
@@ -373,8 +376,8 @@ const Store = (
           return callback();
         } catch (error) {
           this.databaseConnection.emit('sessionError', error, 'clear');
-          if(callback){
-            return callback(error)
+          if (callback) {
+            return callback(error);
           }
         }
       });

--- a/src/store.ts
+++ b/src/store.ts
@@ -155,14 +155,15 @@ const Store = (
       error: StoreError,
       callback?: CommonCallback | GetCallback | LengthCallback | ReadyCallback,
     ) {
-      if (callback) {
-        callback(error);
-      }
       // Attachs sessionError event listener and emits on error on any
       // store error and includes method where error occured
       // eslint-disable-next-line no-shadow
       this.databaseConnection.on('sessionError', (error, method) => this.emit('sessionError', error, method));
-      return this.databaseConnection.emit('sessionError', error, method);
+      this.databaseConnection.emit('sessionError', error, method);
+      if (callback) {
+        return callback(error);
+      }
+      return undefined;
     }
 
     // ////////////////////////////////////////////////////////////////

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,14 +38,14 @@ export interface StoreOptions {
    */
   useUTC?: boolean;
 }
-export type Errors = ConnectionError | Error | null;
+export type StoreError = ConnectionError | Error | null;
 export type GetCallback = (
-  error: Errors,
+  error: StoreError,
   session?: Express.SessionData | null
 ) => void;
-export type LengthCallback = (error: Errors, length?: number) => void;
-export type CommonCallback = (args?: any[] | null | Errors) => void;
-export type ReadyCallback = (error: Errors, cb?: any) => Promise<any>;
+export type LengthCallback = (error: StoreError, length?: number) => void;
+export type CommonCallback = (args?: any[] | null | StoreError) => void;
+export type ReadyCallback = (error: StoreError, cb?: any) => Promise<any>;
 
 export interface IMSSQLStore {
   config: SQLConfig;
@@ -151,8 +151,8 @@ const Store = (
     }
 
     errorHandler(
-      method: string,
-      error: Errors,
+      method: keyof IMSSQLStore,
+      error: StoreError,
       callback?: CommonCallback | GetCallback | LengthCallback | ReadyCallback,
     ) {
       if (callback) {
@@ -173,7 +173,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     get(sid: string, callback: GetCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -205,7 +205,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     set(sid: string, session: Express.SessionData, callback: CommonCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -251,7 +251,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     touch(sid: string, session: Express.SessionData, callback: CommonCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -290,7 +290,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     destroy(sid: string, callback: CommonCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -312,7 +312,7 @@ const Store = (
     // Destroy expired sessions
     // //////////////////////////////////////////////////////////////
     destroyExpired(callback: CommonCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -343,7 +343,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     length(callback: LengthCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }
@@ -368,7 +368,7 @@ const Store = (
      */
     // //////////////////////////////////////////////////////////////
     clear(callback: CommonCallback) {
-      this.ready(async (error: Errors) => {
+      this.ready(async (error: StoreError) => {
         if (error) {
           return callback(error);
         }

--- a/src/store.ts
+++ b/src/store.ts
@@ -108,6 +108,9 @@ const Store = (
       try {
         this.databaseConnection.on('connect', () => this.emit('connect', this));
         this.databaseConnection.on('error', error => this.emit('error', error));
+        this.databaseConnection.on('sessionError', (error, method) =>
+          this.emit('sessionError', error, method)
+        );
         await this.databaseConnection.connect();
         this.databaseConnection.emit('connect');
         if (this.autoRemove) {
@@ -135,7 +138,9 @@ const Store = (
         throw new Error('Connection is closed.') as ConnectionError;
       } catch (error) {
         this.databaseConnection!.emit('error', error);
-        return callback.call(this, error);
+        if (callback) {
+          return callback.call(this, error);
+        }
       }
     }
     //////////////////////////////////////////////////////////////////
@@ -148,7 +153,7 @@ const Store = (
     get(sid: string, callback: GetCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -162,7 +167,10 @@ const Store = (
 
           return callback(null, null);
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'get');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -179,7 +187,7 @@ const Store = (
     set(sid: string, session: Express.SessionData, callback: CommonCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -209,7 +217,10 @@ const Store = (
 
           return callback();
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'set');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -225,7 +236,7 @@ const Store = (
     touch(sid: string, session: Express.SessionData, callback: CommonCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -249,7 +260,10 @@ const Store = (
 
           return callback();
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'touch');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -264,7 +278,7 @@ const Store = (
     destroy(sid: string, callback: CommonCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -275,7 +289,10 @@ const Store = (
 
           return callback();
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'destroy');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -285,7 +302,7 @@ const Store = (
     destroyExpired(callback: CommonCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -302,7 +319,10 @@ const Store = (
           if (this.autoRemoveCallback) {
             this.autoRemoveCallback(error);
           }
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'destroyExpired');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -315,7 +335,7 @@ const Store = (
     length(callback: LengthCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -326,7 +346,10 @@ const Store = (
 
           return callback(null, result.recordset[0].length);
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'length');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }
@@ -339,7 +362,7 @@ const Store = (
     clear(callback: CommonCallback) {
       this.ready(async (error: Errors) => {
         if (error) {
-          return callback(error);
+          throw error;
         }
 
         try {
@@ -349,7 +372,10 @@ const Store = (
 
           return callback();
         } catch (error) {
-          return callback(error);
+          this.databaseConnection.emit('sessionError', error, 'clear');
+          if(callback){
+            return callback(error)
+          }
         }
       });
     }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -188,26 +188,27 @@ describe('connect-mssql-v2', () => {
         done();
       });
     });
+    describe('sessionError Listener', () => {
+      test('Should emit sessionError (errorHandler called directly)', done => {
+        const store = new MSSQLStore(sqlConfig, {
+          table: 'Sessions'
+        });
 
-    test('Should emit sessionError listener', done => {
-      const store = new MSSQLStore(sqlConfig, {
-        table: 'Sessions'
+        store.on('sessionError', (error: any, method: string) => {
+          expect(method).toEqual('test');
+          expect(error).toBeInstanceOf(Error);
+
+          done();
+        });
+
+        const errorHandler = store.errorHandler(
+          'test',
+          new Error('Test errorHandler'),
+          () => true
+        );
+
+        expect(errorHandler).toBeTruthy();
       });
-
-      store.on('sessionError', (error: any, method: string) => {
-        expect(method).toEqual('test');
-        expect(error).toBeInstanceOf(Error);
-
-        done();
-      });
-
-      const errorHandler = store.errorHandler(
-        'test',
-        new Error('Test errorHandler'),
-        () => true
-      );
-
-      expect(errorHandler).toBeTruthy();
     });
 
     test('Should emit an error listener', done => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -209,5 +209,6 @@ describe('connect-mssql-v2', () => {
         done();
       });
     });
+    test.todo('Should emit session error listener')
   });
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -188,6 +188,28 @@ describe('connect-mssql-v2', () => {
         done();
       });
     });
+
+    test('Should emit sessionError listener', done => {
+      const store = new MSSQLStore(sqlConfig, {
+        table: 'Sessions'
+      });
+
+      store.on('sessionError', (error: any, method: string) => {
+        expect(method).toEqual('test');
+        expect(error).toBeInstanceOf(Error);
+
+        done();
+      });
+
+      const errorHandler = store.errorHandler(
+        'test',
+        new Error('Test errorHandler'),
+        () => true
+      );
+
+      expect(errorHandler).toBeTruthy();
+    });
+
     test('Should emit an error listener', done => {
       const localConfig = {
         user: process.env.SQLUSER,
@@ -209,6 +231,5 @@ describe('connect-mssql-v2', () => {
         done();
       });
     });
-    test.todo('Should emit session error listener')
   });
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -226,6 +226,26 @@ describe('connect-mssql-v2', () => {
 
         expect(errorHandler).toBeTruthy();
       });
+
+      test('Should emit sessionError (errorHandler called directly, NO CB)', (done) => {
+        const store = new MSSQLStore(sqlConfig, {
+          table: 'Sessions',
+        });
+
+        store.on('sessionError', (error: any, method: string) => {
+          expect(method).toEqual('test');
+          expect(error).toBeInstanceOf(Error);
+
+          done();
+        });
+
+        const errorHandler = store.errorHandler(
+          'test',
+          new Error('Test errorHandler'),
+        );
+
+        expect(errorHandler).toBeFalsy();
+      });
     });
 
     test('Should emit an error listener', (done) => {


### PR DESCRIPTION
@bradtaniguchi Can you review this PR? I have created the `sessionError` event listener/emitter. This is called from within the `errorHandler` method which is called from the `catch` blocks. It sends the error and the method from which the error occurred. Additionally, I check in the `errorHandler` whether the `callback` exists, and only call it if so.  
I created a test that only tests the `errorHandler` method (all tests pass). If you're able to come up with a way to test from within the actual methods (I'm not positive on how to throw an error within the method for the purpose of testing only), that would be great.