### PR TITLE
Switched "all" methods return from sessionData[] to { [sid: string]: sessionData }

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -187,7 +187,7 @@ const Store = (
           if (result.recordset.length) {
             const returnObject: { [sid: string]: Express.SessionData; } = {};
             for (let i = 0; i < result.recordset.length; i += 1) {
-              returnObject[result.recordset[i].sid] = result.recordset[i].session;
+              returnObject[result.recordset[i].sid] = JSON.parse(result.recordset[i].session);
             }
 
             return callback(null, returnObject);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -99,8 +99,8 @@ describe('connect-mssql-v2', () => {
       store.all((err: any, session: any) => {
         if (err) return done(err);
 
-        expect(session).toHaveLength(2);
-        expect(JSON.parse(session[1].session).somevalue).toBe('yes');
+        expect(Object.keys(session)).toHaveLength(2);
+        expect(session['5678DEF'].somevalue).toBe('yes');
 
         store.destroy('5678DEF');
         return done();


### PR DESCRIPTION
**What:**
Switched "all" methods return from `sessionData[]` to `{ [sid: string]: sessionData }`,
so it is possible to retrieve the sid of all sessions. Adjusted documentation.

**Why:**
I wanted to use the all method to find all sessions and then destroy all sessions for certain users / tokens. Without the sid it's not possible to destroy certain sessions. And my first implementation for the all method would not include sids.

**Why not: { sid: string, data: sessionData }[]**
I actually would have prefered to return` { sid: string, data: sessionData }[]` to easily link sid and session data but when looking at express-session index.d.ts I only found:

`all: (callback: (err: any, obj?: { [sid: string]: Express.SessionData; } | null) => void) => void;`