### PR TITLE
Fixed race condition on first start-up

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -124,6 +124,7 @@ class MSSQLStore extends ExpressSessionStore implements MSSQLStoreDef, IMSSQLSto
   private async dbReadyCheck() {
     try {
       if (!this.databaseConnection.connected && !this.databaseConnection.connecting) {
+        await new Promise((r) => setTimeout(r, 5));
         await this.initializeDatabase();
       }
 


### PR DESCRIPTION
I noticed I'm getting an error of "Connection is closed" on first starting up the express Node app. 

![image](https://user-images.githubusercontent.com/48596856/185441925-11966849-70d5-4243-b5e2-a6a5e0b3c219.png)
The store functions properly and all works well, but it is an annoying error that always shows up on app-start up. After testing it out, it seems like it's a race condition, and adding a small delay of 0.05 seconds fixes this issue. That is what this PR is for.