### PR TITLE
fix: pipeline runtime issues

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   # TODO: Add windows build if possible
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
 
     strategy:
       matrix:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   # TODO: Add windows build if possible
   build-linux:
+    # last version that natively works with sqlcmd via the mssqlsuite
+    # not really sure why this doesn't work with 24 as mssqlsuite should
+    # handle it, might need to migrate in the future
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - name: Install a SQL Server suite of tools
-        uses: potatoqualitee/mssqlsuite@v1.5.1
+        uses: potatoqualitee/mssqlsuite@v1.8
         with:
           install: sqlengine
       - name: Seed session table

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   # TODO: Add windows build if possible
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   # TODO: Add windows build if possible
   build-linux:
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
- bump mssqlsuite github action version, should fix the missing sqlcmd error seen earlier, as per the changelog of this github action.
- set ubuntu version explicitly, as I guess sqlcmd only exists in specific ubuntu versions, so latest broke (which is currently 25)

Close #85