### PR TITLE
Fix #91 - properly handle false for useUTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All project updates will be documented in this file
 
+## [v5.2.1] - 2025-06-16
+
+- Fix #91 - `useUTC` is always `true` even if `false` is provided. Replaced `||` with `??`
+
 ## [v5.2.0] - 2025-05-22
 
 - Adds optional retry attempts to database connection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mssql-v2",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "MS SQL Server session store for Express Session",
   "main": "dist/src/store",
   "types": "dist/src/store.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -114,7 +114,7 @@ class MSSQLStore extends ExpressSessionStore implements MSSQLStoreDef {
     this.autoRemoveInterval = options?.autoRemoveInterval || 1000 * 60 * 10;
     this.preRemoveCallback = options?.preRemoveCallback || undefined;
     this.autoRemoveCallback = options?.autoRemoveCallback || undefined;
-    this.useUTC = options?.useUTC || true;
+    this.useUTC = options?.useUTC ?? true;
     this.retries = options?.retries || 0;
     this.retryDelay = options?.retryDelay || 1000;
     this.config = config;


### PR DESCRIPTION
- Fixes #91 by replacing `||` to `??` so that `false` is not the same as `undefined`